### PR TITLE
Base 3.6 image off python 3.6.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,8 +39,10 @@ stages:
     strategy:
       matrix:
         Python36:
-          pythonVersion: '3.6'
+          tagVersion: '3.6'
+          pythonVersion: '3.6.0'
         Python37:
+          tagVersion: '3.7'
           pythonVersion: '3.7'
     steps:
     - script: sudo docker login -u $(dockerUser) -p $(dockerPassword)
@@ -50,6 +52,6 @@ stages:
 
         sudo docker build \
           --build-arg PYTHON_VERSION=$(pythonVersion) \
-          --tag homeassistant/ci-azure:$(pythonVersion) .
+          --tag homeassistant/ci-azure:$(tagVersion) .
 
-        sudo docker push homeassistant/ci-azure:$(pythonVersion)
+        sudo docker push homeassistant/ci-azure:$(tagVersion)


### PR DESCRIPTION
https://github.com/home-assistant/home-assistant/pull/26030#issuecomment-522298190

I haven't been able to test this myself, but guess it would work. Keeping the image tag at 3.6 provides for not requiring any changes in HA, but obviously that can be changed to 3.6.0 if there's a preference for that.