### PR TITLE
Base 3.6 image off python 3.6.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,8 +39,10 @@ stages:
     strategy:
       matrix:
         Python36:
-          pythonVersion: '3.6'
+          tagVersion: '3.6'
+          pythonVersion: '3.6.1'
         Python37:
+          tagVersion: '3.7'
           pythonVersion: '3.7'
     steps:
     - script: sudo docker login -u $(dockerUser) -p $(dockerPassword)
@@ -50,6 +52,6 @@ stages:
 
         sudo docker build \
           --build-arg PYTHON_VERSION=$(pythonVersion) \
-          --tag homeassistant/ci-azure:$(pythonVersion) .
+          --tag homeassistant/ci-azure:$(tagVersion) .
 
-        sudo docker push homeassistant/ci-azure:$(pythonVersion)
+        sudo docker push homeassistant/ci-azure:$(tagVersion)


### PR DESCRIPTION
Per https://github.com/home-assistant/architecture/issues/278

No need to wait for the next version IMO, this could be done already now.

Same caveats as in #2 apply wrt not being able to actually test this myself. But 3.6.1 works in Travis.