### PR TITLE
Point Python 3.7 image at Python 3.7.1

### DIFF
--- a/python/Dockerfile-3.7
+++ b/python/Dockerfile-3.7
@@ -30,7 +30,7 @@ RUN \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.7.0
+ENV PYTHON_VERSION 3.7.1
 
 RUN set -ex \
 	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \


### PR DESCRIPTION
This is going to be the new minimum version and this change is already necessary for testing https://github.com/home-assistant/core/pull/37184