### PR TITLE
Fix GPG key fetching, replacing the sks pools

### DIFF
--- a/python/Dockerfile-3.8
+++ b/python/Dockerfile-3.8
@@ -32,7 +32,7 @@ RUN set -ex \
   && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
   && export GNUPGHOME="$(mktemp -d)" \
   && echo "disable-ipv6" >> "$GNUPGHOME/dirmngr.conf" \
-  && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+  && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY" \
   && gpg --batch --verify python.tar.xz.asc python.tar.xz \
   && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
   && rm -rf "$GNUPGHOME" python.tar.xz.asc \

--- a/python/Dockerfile-3.9
+++ b/python/Dockerfile-3.9
@@ -32,7 +32,7 @@ RUN set -ex \
   && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
   && export GNUPGHOME="$(mktemp -d)" \
   && echo "disable-ipv6" >> "$GNUPGHOME/dirmngr.conf" \
-  && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+  && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY" \
   && gpg --batch --verify python.tar.xz.asc python.tar.xz \
   && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
   && rm -rf "$GNUPGHOME" python.tar.xz.asc \


### PR DESCRIPTION
The GPG SKS pools are taken offline, and openpgp.org is now the defacto standard for fetching GPG keys.

This PR adjusts existing Python builds for that.