### PR TITLE
Add Python 3.10 (b4)

### DIFF
--- a/python/Dockerfile-3.10
+++ b/python/Dockerfile-3.10
@@ -1,0 +1,96 @@
+FROM buildpack-deps:buster
+
+# Ensure local python is preferred over distribution python
+ENV PATH /usr/local/bin:$PATH
+ENV DEBIAN_FRONTEND noninteractive
+
+# http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
+# Set shell
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Setup requirements
+RUN \
+  apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libavcodec-dev \
+    libavdevice-dev \
+    libavfilter-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libswresample-dev \
+    libswscale-dev \
+    libudev-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
+ENV PYTHON_VERSION 3.10.0b4
+
+RUN set -ex \
+  && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+  && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && echo "disable-ipv6" >> "$GNUPGHOME/dirmngr.conf" \
+  && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY" \
+  && gpg --batch --verify python.tar.xz.asc python.tar.xz \
+  && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+  && rm -rf "$GNUPGHOME" python.tar.xz.asc \
+  && mkdir -p /usr/src/python \
+  && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+  && rm python.tar.xz \
+  \
+  && cd /usr/src/python \
+  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+  && ./configure \
+    --build="$gnuArch" \
+    --enable-loadable-sqlite-extensions \
+    --enable-optimizations \
+    --enable-shared \
+    --with-system-expat \
+    --with-system-ffi \
+    --without-ensurepip \
+  && make -j "$(nproc)" \
+  && make install \
+  && ldconfig \
+  \
+  && find /usr/local -depth \
+    \( \
+      \( -type d -a \( -name test -o -name tests \) \) \
+      -o \
+      \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+    \) -exec rm -rf '{}' + \
+  && rm -rf /usr/src/python \
+  \
+  && python3 --version
+
+# make some useful symlinks that are expected to exist
+RUN cd /usr/local/bin \
+  && ln -s idle3 idle \
+  && ln -s pydoc3 pydoc \
+  && ln -s python3 python \
+  && ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 20.2.4
+
+RUN set -ex; \
+  \
+  wget -O get-pip.py "https://bootstrap.pypa.io/get-pip.py"; \
+  \
+  python get-pip.py \
+    --disable-pip-version-check \
+    --no-cache-dir \
+    "pip==$PYTHON_PIP_VERSION" \
+  ; \
+  pip --version; \
+  \
+  find /usr/local -depth \
+    \( \
+      \( -type d -a \( -name test -o -name tests \) \) \
+      -o \
+      \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+    \) -exec rm -rf '{}' +; \
+  rm -f get-pip.py
+
+CMD ["python3"]


### PR DESCRIPTION
Start of adding Python 3.10 to our builds.

This is currently based on Python 3.10 beta 4, which is the latest available.