### PR TITLE
Upgrade Python 3.9 PIP to 20.2.4

### DIFF
--- a/python/Dockerfile-3.9
+++ b/python/Dockerfile-3.9
@@ -118,7 +118,7 @@ RUN cd /usr/local/bin \
   && ln -s python3-config python-config
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.1.1
+ENV PYTHON_PIP_VERSION 20.2.4
 
 RUN set -ex; \
   \


### PR DESCRIPTION
Upgrades Python 3.9 with PIP 20.2.4
(other are correct already)