### PR TITLE
Upgrade Python3.10 to 3.10.0

### DIFF
--- a/python/Dockerfile-3.10
+++ b/python/Dockerfile-3.10
@@ -25,7 +25,7 @@ RUN \
   && rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
-ENV PYTHON_VERSION 3.10.0b4
+ENV PYTHON_VERSION 3.10.0
 
 RUN set -ex \
   && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \


### PR DESCRIPTION
Upgrades the Python 3.10 container to the final/stable release of Python 3.10.0